### PR TITLE
Add Firefox and Edge export support

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,47 +8,19 @@ var path = require("path");
 
 var package_version = package.version.replaceAll(".", "_");
 
-BASE_BUILD = "build/base";
-BUILD_INTER = "build/intermediates";
-FIREFOX_BUILD = "build/firefox";
+const BASE_BUILD = "build/base";
+const BUILD_INTER = "build/intermediates";
+const FIREFOX_BUILD = "build/firefox";
 
 const PATHS = {
-	assets: {
-		src: "src/assets/**",
-		dest: `${BASE_BUILD}/assets`,
-	},
-	css: {
-		src: "src/css/**",
-		dest: `${BASE_BUILD}/css`,
-	},
-	content: {
-		src: "content/**",
-		dest: `${BASE_BUILD}/content`,
-	},
-	extension: {
-		src: "src/extension/**",
-		dest: `${BASE_BUILD}/extension`,
-	},
-	lib: {
-		src: "lib/**",
-		dest: `${BASE_BUILD}/lib`,
-	},
-	background: {
-		src: "src/background.js",
-		dest: BASE_BUILD,
-	},
-	index: {
-		src: "src/index.html",
-		dest: BASE_BUILD,
-	},
-	manifest: {
-		src: "manifest.json",
-		dest: BASE_BUILD,
-	},
-	readme: {
-		src: "README.md",
-		dest: BASE_BUILD,
-	},
+	assets:     { src: "src/assets/**",    dest: `${BASE_BUILD}/assets` },
+	css:        { src: "src/css/**",       dest: `${BASE_BUILD}/css` },
+	extension:  { src: "src/extension/**", dest: `${BASE_BUILD}/extension` },
+	lib:        { src: "lib/**",           dest: `${BASE_BUILD}/lib` },
+	background: { src: "src/background.js",dest: BASE_BUILD },
+	index:      { src: "src/index.html",   dest: BASE_BUILD },
+	manifest:   { src: "manifest.json",    dest: BASE_BUILD },
+	readme:     { src: "README.md",        dest: BASE_BUILD },
 };
 
 const UTILS = ["src/common/store.js", "src/common/util.js"];
@@ -75,49 +47,43 @@ const TARGETS = {
 	],
 };
 
+// --- Copy helpers derived from PATHS ---
+
+const copies = Object.fromEntries(
+	Object.entries(PATHS).map(([key, { src, dest }]) => [
+		key,
+		() => gulp.src(src).pipe(gulp.dest(dest)),
+	])
+);
+
+// --- Content script bundling ---
+
 const targets = {};
 for (const target in TARGETS) {
-	const task = {
-		[target]: () => {
-			return gulp
-				.src(TARGETS[target])
-				.pipe(gulp_concat(`${target}.js`))
-				.pipe(gulp.dest(`${BUILD_INTER}/content/`));
-		},
-	};
-	targets[target] = task[target];
+	targets[target] = () =>
+		gulp
+			.src(TARGETS[target])
+			.pipe(gulp_concat(`${target}.js`))
+			.pipe(gulp.dest(`${BUILD_INTER}/content/`));
 	// Add specific task. usage: `npm run gulp shieldmaiden_character`
 	gulp.task(target, targets[target]);
 }
 
-const build_content = gulp.series(...Object.values(targets));
-
-const copy_content_nobuild = () =>
+const build_content_scripts = gulp.series(...Object.values(targets));
+const copy_content_to_base = () =>
 	gulp.src(`${BUILD_INTER}/content/**`).pipe(gulp.dest(`${BASE_BUILD}/content/`));
-
 const clean_content = () =>
 	gulp.src(`${BUILD_INTER}/content`, { read: false, allowEmpty: true }).pipe(gulp_clean());
+const build_content = gulp.series(clean_content, build_content_scripts, copy_content_to_base);
 
-const copy_content = gulp.series(clean_content, build_content, copy_content_nobuild);
+// --- Base build ---
 
 const clean_build = () =>
 	gulp.src("./build/", { read: false, allowEmpty: true }).pipe(gulp_clean());
 
-const copy_assets = () => gulp.src(PATHS.assets.src).pipe(gulp.dest(PATHS.assets.dest));
+const build_base = gulp.parallel(build_content, ...Object.values(copies));
 
-const copy_css = () => gulp.src(PATHS.css.src).pipe(gulp.dest(PATHS.css.dest));
-
-const copy_extension = () => gulp.src(PATHS.extension.src).pipe(gulp.dest(PATHS.extension.dest));
-
-const copy_lib = () => gulp.src(PATHS.lib.src).pipe(gulp.dest(PATHS.lib.dest));
-
-const copy_background = () => gulp.src(PATHS.background.src).pipe(gulp.dest(PATHS.background.dest));
-
-const copy_index = () => gulp.src(PATHS.index.src).pipe(gulp.dest(PATHS.index.dest));
-
-const copy_manifest = () => gulp.src(PATHS.manifest.src).pipe(gulp.dest(PATHS.manifest.dest));
-
-const copy_readme = () => gulp.src(PATHS.readme.src).pipe(gulp.dest(PATHS.readme.dest));
+// --- Manifest helpers ---
 
 const update_manifest_version = (done) => {
 	const manifest = JSON.parse(fs.readFileSync("manifest.json"));
@@ -138,42 +104,7 @@ const strip_localhost = (done) => {
 	done();
 };
 
-const watch_targets = () => {
-	for (const target in TARGETS) {
-		gulp.watch(TARGETS[target], targets[target]);
-	}
-	gulp.watch(`${BUILD_INTER}/content/**`, copy_content_nobuild);
-};
-
-const watch = () => {
-	watch_targets();
-	gulp.watch(PATHS.assets.src, copy_assets);
-	gulp.watch(PATHS.css.src, copy_css);
-	gulp.watch(PATHS.extension.src, copy_extension);
-	gulp.watch(PATHS.lib.src, copy_lib);
-	gulp.watch(PATHS.background.src, copy_background);
-	gulp.watch(PATHS.index.src, copy_index);
-	gulp.watch(PATHS.manifest.src, copy_manifest);
-	gulp.watch(PATHS.content.src, copy_content);
-};
-
-const build_base = gulp.parallel([
-	copy_content,
-	copy_extension,
-	copy_background,
-	copy_manifest,
-	copy_index,
-	copy_assets,
-	copy_css,
-	copy_lib,
-	copy_readme,
-]);
-
-const zip_base = () =>
-	gulp
-		.src(`${BASE_BUILD}/**`)
-		.pipe(zip(`dndCharacterSync-${package_version}.zip`))
-		.pipe(gulp.dest("./dist"));
+// --- Firefox build ---
 
 const build_firefox_manifest = (done) => {
 	const manifest = JSON.parse(fs.readFileSync(`${BASE_BUILD}/manifest.json`));
@@ -187,6 +118,7 @@ const build_firefox_manifest = (done) => {
 				"*://*.shieldmaiden.app/*",
 				"*://harmlesskey.com/*",
 				"*://*.harmlesskey.com/*",
+				"*://localhost/*",
 			],
 			js: ["content/bridge.js"],
 			run_at: "document_start",
@@ -220,11 +152,19 @@ const fix_firefox_css = (done) => {
 	done();
 };
 
-const build_firefox_base = gulp.series(
+const build_firefox = gulp.series(
 	gulp.parallel(copy_base_to_firefox, copy_bridge_script),
 	fix_firefox_css,
 	build_firefox_manifest
 );
+
+// --- Zip tasks ---
+
+const zip_base = () =>
+	gulp
+		.src(`${BASE_BUILD}/**`)
+		.pipe(zip(`dndCharacterSync-${package_version}.zip`))
+		.pipe(gulp.dest("./dist"));
 
 const zip_firefox = async () => {
 	const webExt = require("web-ext").default;
@@ -245,22 +185,64 @@ const zip_edge = () =>
 		.pipe(zip(`dndCharacterSync-edge-${package_version}.zip`))
 		.pipe(gulp.dest("./dist"));
 
+// --- Watch ---
+
+const watch_content_scripts = () => {
+	for (const target in TARGETS) {
+		gulp.watch(TARGETS[target], targets[target]);
+	}
+	gulp.watch(`${BUILD_INTER}/content/**`, copy_content_to_base);
+};
+
+const watch = () => {
+	watch_content_scripts();
+	for (const [key, { src }] of Object.entries(PATHS)) {
+		gulp.watch(src, copies[key]);
+	}
+};
+
+const watch_firefox = () => {
+	watch();
+	gulp.watch(`${BASE_BUILD}/**`, build_firefox);
+};
+
+// --- Export pipeline ---
+
+const strip_dev = (done) => {
+	const file_path = `${BASE_BUILD}/background.js`;
+	const content = fs.readFileSync(file_path, "utf8");
+	fs.writeFileSync(
+		file_path,
+		content
+			.split("\n")
+			.filter((line) => !line.includes("// DEV"))
+			.join("\n")
+	);
+	done();
+};
+
+const strip_firefox_localhost = (done) => {
+	const manifest_path = `${FIREFOX_BUILD}/manifest.json`;
+	const manifest = JSON.parse(fs.readFileSync(manifest_path));
+	manifest.content_scripts = manifest.content_scripts.map((entry) => ({
+		...entry,
+		matches: entry.matches.filter((match) => !match.includes("localhost")),
+	}));
+	fs.writeFileSync(manifest_path, JSON.stringify(manifest, null, 2));
+	done();
+};
+
+const prepare_export = gulp.series(clean_build, update_manifest_version, build_base, strip_localhost, strip_dev);
+const export_firefox = gulp.series(build_firefox, strip_firefox_localhost, zip_firefox);
+
 exports.build = gulp.series(clean_build, build_base);
-exports["build:firefox"] = gulp.series(clean_build, build_base, build_firefox_base);
-exports.export = gulp.series(clean_build, update_manifest_version, build_base, strip_localhost, zip_base);
-exports["export:firefox"] = gulp.series(
-	clean_build,
-	update_manifest_version,
-	build_base,
-	strip_localhost,
-	build_firefox_base,
-	zip_firefox
-);
-exports["export:edge"] = gulp.series(
-	clean_build,
-	update_manifest_version,
-	build_base,
-	strip_localhost,
-	zip_edge
+exports["build:firefox"] = gulp.series(clean_build, build_base, build_firefox);
+exports.export = gulp.series(prepare_export, zip_base);
+exports["export:firefox"] = gulp.series(prepare_export, export_firefox);
+exports["export:edge"] = gulp.series(prepare_export, zip_edge);
+exports["export:all"] = gulp.series(
+	prepare_export,
+	gulp.parallel(zip_base, zip_edge, export_firefox)
 );
 exports.default = gulp.series(clean_build, build_base, watch);
+exports["watch:firefox"] = gulp.series(clean_build, build_base, build_firefox, watch_firefox);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,11 +4,13 @@ var gulp_clean = require("gulp-clean");
 var zip = require("gulp-zip");
 var package = require("./package.json");
 var fs = require("fs");
+var path = require("path");
 
 var package_version = package.version.replaceAll(".", "_");
 
 BASE_BUILD = "build/base";
 BUILD_INTER = "build/intermediates";
+FIREFOX_BUILD = "build/firefox";
 
 const PATHS = {
 	assets: {
@@ -127,9 +129,11 @@ const update_manifest_version = (done) => {
 const strip_localhost = (done) => {
 	const manifest_path = `${BASE_BUILD}/manifest.json`;
 	const manifest = JSON.parse(fs.readFileSync(manifest_path));
-	manifest.externally_connectable.matches = manifest.externally_connectable.matches.filter(
-		(match) => !match.includes("localhost")
-	);
+	if (manifest.externally_connectable) {
+		manifest.externally_connectable.matches = manifest.externally_connectable.matches.filter(
+			(match) => !match.includes("localhost")
+		);
+	}
 	fs.writeFileSync(manifest_path, JSON.stringify(manifest, null, 2));
 	done();
 };
@@ -171,6 +175,73 @@ const zip_base = () =>
 		.pipe(zip(`dndCharacterSync-${package_version}.zip`))
 		.pipe(gulp.dest("./dist"));
 
+const build_firefox_manifest = (done) => {
+	const manifest = JSON.parse(fs.readFileSync(`${BASE_BUILD}/manifest.json`));
+	delete manifest.background.type;
+	delete manifest.externally_connectable;
+	manifest.content_scripts = [
+		...(manifest.content_scripts || []),
+		{
+			matches: [
+				"*://shieldmaiden.app/*",
+				"*://*.shieldmaiden.app/*",
+				"*://harmlesskey.com/*",
+				"*://*.harmlesskey.com/*",
+			],
+			js: ["content/bridge.js"],
+			run_at: "document_start",
+		},
+	];
+	fs.mkdirSync(FIREFOX_BUILD, { recursive: true });
+	fs.writeFileSync(`${FIREFOX_BUILD}/manifest.json`, JSON.stringify(manifest, null, 2));
+	done();
+};
+
+const copy_base_to_firefox = () =>
+	gulp.src([`${BASE_BUILD}/**`, `!${BASE_BUILD}/manifest.json`]).pipe(gulp.dest(FIREFOX_BUILD));
+
+const copy_bridge_script = () =>
+	gulp.src("src/content/bridge/bridge.js").pipe(gulp.dest(`${FIREFOX_BUILD}/content`));
+
+const build_firefox_base = gulp.series(
+	gulp.parallel(copy_base_to_firefox, copy_bridge_script),
+	build_firefox_manifest
+);
+
+const zip_firefox = async () => {
+	const webExt = require("web-ext").default;
+	await webExt.cmd.build(
+		{
+			sourceDir: path.resolve(FIREFOX_BUILD),
+			artifactsDir: path.resolve("./dist"),
+			filename: `dndCharacterSync-firefox-${package_version}.zip`,
+			overwriteDest: true,
+		},
+		{ shouldExitProgram: false }
+	);
+};
+
+const zip_edge = () =>
+	gulp
+		.src(`${BASE_BUILD}/**`)
+		.pipe(zip(`dndCharacterSync-edge-${package_version}.zip`))
+		.pipe(gulp.dest("./dist"));
+
 exports.build = gulp.series(clean_build, build_base);
 exports.export = gulp.series(clean_build, update_manifest_version, build_base, strip_localhost, zip_base);
+exports["export:firefox"] = gulp.series(
+	clean_build,
+	update_manifest_version,
+	build_base,
+	strip_localhost,
+	build_firefox_base,
+	zip_firefox
+);
+exports["export:edge"] = gulp.series(
+	clean_build,
+	update_manifest_version,
+	build_base,
+	strip_localhost,
+	zip_edge
+);
 exports.default = gulp.series(clean_build, build_base, watch);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -177,7 +177,7 @@ const zip_base = () =>
 
 const build_firefox_manifest = (done) => {
 	const manifest = JSON.parse(fs.readFileSync(`${BASE_BUILD}/manifest.json`));
-	delete manifest.background.type;
+	manifest.background = { scripts: [manifest.background.service_worker] };
 	delete manifest.externally_connectable;
 	manifest.content_scripts = [
 		...(manifest.content_scripts || []),
@@ -192,6 +192,13 @@ const build_firefox_manifest = (done) => {
 			run_at: "document_start",
 		},
 	];
+	manifest.browser_specific_settings = {
+		gecko: { id: "dnd-character-sync@harmlesskey.com" },
+	};
+	manifest.web_accessible_resources = [
+		...(manifest.web_accessible_resources || []),
+		{ resources: ["assets/fonts/*"], matches: ["<all_urls>"] },
+	];
 	fs.mkdirSync(FIREFOX_BUILD, { recursive: true });
 	fs.writeFileSync(`${FIREFOX_BUILD}/manifest.json`, JSON.stringify(manifest, null, 2));
 	done();
@@ -203,8 +210,19 @@ const copy_base_to_firefox = () =>
 const copy_bridge_script = () =>
 	gulp.src("src/content/bridge/bridge.js").pipe(gulp.dest(`${FIREFOX_BUILD}/content`));
 
+const fix_firefox_css = (done) => {
+	const dir = `${FIREFOX_BUILD}/css/font-awesome`;
+	fs.readdirSync(dir).forEach((file) => {
+		const p = `${dir}/${file}`;
+		const content = fs.readFileSync(p, "utf8");
+		fs.writeFileSync(p, content.replaceAll("chrome-extension://", "moz-extension://"));
+	});
+	done();
+};
+
 const build_firefox_base = gulp.series(
 	gulp.parallel(copy_base_to_firefox, copy_bridge_script),
+	fix_firefox_css,
 	build_firefox_manifest
 );
 
@@ -228,6 +246,7 @@ const zip_edge = () =>
 		.pipe(gulp.dest("./dist"));
 
 exports.build = gulp.series(clean_build, build_base);
+exports["build:firefox"] = gulp.series(clean_build, build_base, build_firefox_base);
 exports.export = gulp.series(clean_build, update_manifest_version, build_base, strip_localhost, zip_base);
 exports["export:firefox"] = gulp.series(
 	clean_build,

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "author": "Harm Manders & Key Roos",
   "name": "D&D Character Sync",
   "description": "Store character sheets from different D&D apps",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "background": {
     "service_worker": "background.js",
     "type": "module"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dnd-character-sync",
-	"version": "0.9.4",
+	"version": "0.9.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dnd-character-sync",
-			"version": "0.9.4",
+			"version": "0.9.5",
 			"devDependencies": {
 				"@types/gulp": "^4.0.10",
 				"@types/gulp-concat": "^0.0.33",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"export": "gulp export",
 		"export:firefox": "gulp export:firefox",
 		"export:edge": "gulp export:edge",
-		"start:firefox": "web-ext run --source-dir=build/firefox"
+		"build:firefox": "gulp build:firefox"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dnd-character-sync",
-	"version": "0.9.4",
+	"version": "0.9.5",
 	"description": "A Chrome extension that grabs your Dungeons & Dragons character's stats from various platforms like D&D Beyond and Shieldmaiden.",
 	"scripts": {
 		"gulp": "gulp"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
 	"version": "0.9.5",
 	"description": "A Chrome extension that grabs your Dungeons & Dragons character's stats from various platforms like D&D Beyond and Shieldmaiden.",
 	"scripts": {
-		"gulp": "gulp"
+		"gulp": "gulp",
+		"export": "gulp export",
+		"export:firefox": "gulp export:firefox",
+		"export:edge": "gulp export:edge",
+		"start:firefox": "web-ext run --source-dir=build/firefox"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
 		"export": "gulp export",
 		"export:firefox": "gulp export:firefox",
 		"export:edge": "gulp export:edge",
-		"build:firefox": "gulp build:firefox"
+		"export:all": "gulp export:all",
+		"build:firefox": "gulp build:firefox",
+		"watch:firefox": "gulp watch:firefox"
 	},
 	"repository": {
 		"type": "git",

--- a/src/background.js
+++ b/src/background.js
@@ -10,10 +10,26 @@ const getCurrentTab = async () => {
 	return tab;
 };
 
+const getContentScriptFile = (url) => {
+	if (isDndBeyond.test(url)) return "content/dndbeyond_character.js";
+	if (isDiceCloud.test(url)) return "content/dicecloud_character.js";
+	if (isShieldmaiden.test(url)) return "content/shieldmaiden_character.js";
+	return null;
+};
+
 const syncCharacter = async () => {
 	console.log("Sync character");
 	const tab = await getCurrentTab();
-	chrome.tabs.sendMessage(tab.id, { sync: "send id with message in future" });
+	try {
+		await chrome.tabs.sendMessage(tab.id, { sync: "send id with message in future" });
+	} catch {
+		// Content script not running yet (page was open before extension loaded) — inject and retry
+		const file = getContentScriptFile(tab.url);
+		if (file) {
+			await chrome.scripting.executeScript({ target: { tabId: tab.id }, files: [file] });
+			chrome.tabs.sendMessage(tab.id, { sync: "send id with message in future" });
+		}
+	}
 };
 
 chrome.runtime.onInstalled.addListener(async () => {
@@ -75,28 +91,10 @@ chrome.runtime.onMessage.addListener((req, sender, sendResponse) => {
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
 	console.log("Updated tab");
 	if (changeInfo.status === "complete") {
-		if (isDndBeyond.test(tab.url)) {
-			console.log("Is dnd beyond!");
-			chrome.scripting.executeScript({
-				target: { tabId: tabId },
-				files: ["content/dndbeyond_character.js"],
-			});
-		}
-
-		if (isDiceCloud.test(tab.url)) {
-			console.log("Is Dice Cloud!");
-			chrome.scripting.executeScript({
-				target: { tabId: tabId },
-				files: ["content/dicecloud_character.js"],
-			});
-		}
-
-		if (isShieldmaiden.test(tab.url)) {
-			console.log("Is Shieldmaiden (the best dnd app)!");
-			chrome.scripting.executeScript({
-				target: { tabId: tabId },
-				files: ["content/shieldmaiden_character.js"],
-			});
+		const file = getContentScriptFile(tab.url);
+		if (file) {
+			console.log("Injecting content script:", file);
+			chrome.scripting.executeScript({ target: { tabId }, files: [file] });
 		}
 	}
 });

--- a/src/background.js
+++ b/src/background.js
@@ -67,7 +67,8 @@ chrome.runtime.onMessage.addListener((req, sender, sendResponse) => {
 	if (req.CS_BRIDGE) {
 		const isAllowedSender =
 			/^https?:\/\/(.*\.)?shieldmaiden\.app/.test(sender.tab?.url) ||
-			/^https?:\/\/(.*\.)?harmlesskey\.com/.test(sender.tab?.url);
+			/^https?:\/\/(.*\.)?harmlesskey\.com/.test(sender.tab?.url) ||
+			/^https?:\/\/localhost(:\d+)?/.test(sender.tab?.url); // DEV
 		if (isAllowedSender) {
 			chrome.storage.sync.get().then((storage) => {
 				const content = {};

--- a/src/background.js
+++ b/src/background.js
@@ -46,6 +46,30 @@ chrome.runtime.onMessage.addListener((req, sender, sendResponse) => {
 			syncCharacter();
 		}
 	}
+
+	// Firefox bridge: relayed external request from bridge.js content script on Shieldmaiden/HarmlessKey
+	if (req.CS_BRIDGE) {
+		const isAllowedSender =
+			/^https?:\/\/(.*\.)?shieldmaiden\.app/.test(sender.tab?.url) ||
+			/^https?:\/\/(.*\.)?harmlesskey\.com/.test(sender.tab?.url);
+		if (isAllowedSender) {
+			chrome.storage.sync.get().then((storage) => {
+				const content = {};
+				if (Array.isArray(req.request_content)) {
+					if (req.request_content.includes("characters")) {
+						content.characters = Object.fromEntries(
+							Object.entries(storage).filter(([key]) => key !== "config")
+						);
+					}
+					if (req.request_content.includes("version")) {
+						content.version = chrome.runtime.getManifest().version;
+					}
+				}
+				sendResponse(content);
+			});
+			return true; // keep port open for async sendResponse
+		}
+	}
 });
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {

--- a/src/content/bridge/bridge.js
+++ b/src/content/bridge/bridge.js
@@ -1,0 +1,18 @@
+// Firefox bridge: relays window.postMessage from Shieldmaiden/HarmlessKey to the extension background.
+// Required because Firefox does not support externally_connectable or onMessageExternal.
+// The Shieldmaiden website sends window.postMessage({CS_BRIDGE, requestId, ...payload})
+// and listens for window.postMessage({CS_BRIDGE_RESPONSE, requestId, ...response}).
+window.addEventListener("message", (event) => {
+	if (event.source !== window) return;
+	if (!event.data?.CS_BRIDGE) return;
+
+	const { CS_BRIDGE, requestId, ...payload } = event.data;
+
+	chrome.runtime.sendMessage({ CS_BRIDGE: true, requestId, ...payload }, (response) => {
+		window.postMessage({
+			CS_BRIDGE_RESPONSE: true,
+			requestId,
+			...response,
+		}, "*");
+	});
+});

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -4,7 +4,7 @@
 @import "./font-awesome/brands.min.css";
 
 body {
-	min-width: 365px;
+	width: 365px;
 	margin: 0;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 	color: var(--font-color);
@@ -216,6 +216,10 @@ a {
 }
 button, .btn {
 	all: unset;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: .35rem;
 	text-transform: uppercase;
 	background-color: var(--primary);
 	color: var(--white);
@@ -255,26 +259,34 @@ button > * {
 	background-color: var(--neutral-1);
 }
 .btn-logo {
+	display: flex;
+	height: 100px;
 	border: solid 1px var(--primary);
-	font-size: 3rem;
 	color: var(--font-color);
 	text-transform: none;
 }
+.btn-logo:not(:has(.logo)) {
+	font-size: 2rem;
+}
 .logo {
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	width: 200px;
-	height: 80px;
+	height: 75px;
 	margin: auto;
 	background-size: contain;
 	background-repeat: no-repeat;
-	background-position: center top;
-	font-size: 9rem;
-	text-align: center;
+	background-position: center center;
+}
+button .logo {
+	margin: 0;
 }
 .logo__sm {
 	background-image: var(--sm-logo);
 }
 .logo__dndb .fab {
-	line-height: 80px;
+	font-size: 4.5rem;
 }
 
 #tabs { 

--- a/src/index.html
+++ b/src/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 	<head>
 		<link href="./css/styles.css" rel="stylesheet">


### PR DESCRIPTION
## Summary

- **Firefox export**: new `build:firefox`, `export:firefox`, and `watch:firefox` tasks that produce a Firefox-compatible extension build
- **Edge export**: new `export:edge` task (reuses Chrome base build, different zip name)
- **Export all**: `export:all` zips Chrome, Edge, and Firefox in parallel in one command
- **Firefox bridge**: content script (`src/content/bridge/bridge.js`) injected on Shieldmaiden/HarmlessKey pages to relay `window.postMessage` ↔ `chrome.runtime.sendMessage`, working around Firefox's lack of `externally_connectable`
- **Firefox manifest transforms**: background scripts array, gecko ID for `storage.sync`, font `web_accessible_resources`, CSS `chrome-extension://` → `moz-extension://` rewrite, bridge `content_scripts` entry
- **Dev localhost support**: localhost allowed in both the Firefox bridge `content_scripts` and the `CS_BRIDGE` sender check in `background.js`; both are stripped automatically on export via `strip_localhost`, `strip_firefox_localhost`, and `strip_dev`
- **Popup UI fixes**: button layout, logo sizing, and `DOCTYPE` for Firefox compatibility
- **Gulpfile streamlined**: copy tasks and watchers derived generically from `PATHS`; shared `prepare_export` prefix

## Test plan

- `npm run build:firefox` → load `build/firefox/` in Firefox via `about:debugging`, verify popup renders and sync works
- `npm run export:all` → verify three zips appear in `dist/`
- Inspect `dist/dndCharacterSync-firefox-*.zip` manifest: no `externally_connectable`, no localhost in `content_scripts`, no localhost in `background.js`, gecko ID present
- `npm run gulp` (default watch) → edit a source file, verify `build/base/` updates
- `npm run watch:firefox` → edit a source file, verify both `build/base/` and `build/firefox/` update